### PR TITLE
Fixed bug in SQ rule DOC-04 when using default copyright header

### DIFF
--- a/include/ToolBOSCore/SoftwareQuality/Rules.py
+++ b/include/ToolBOSCore/SoftwareQuality/Rules.py
@@ -440,7 +440,7 @@ copyright       =
 
         from ToolBOSCore.Packages.CopyrightHeader import getCopyright
 
-        self._defaultCopyrightHeader = getCopyright()
+        self._defaultCopyrightHeader = getCopyright().splitlines()
 
 
     def run( self, details, files ):


### PR DESCRIPTION
When using the default copyright header getCopyright() returns a string, not a list.
During the check this leads to an iteration over all characters of the string rather than the lines.
Thus not correctly checking for the copyright header, which can result in some files passing the check if they contain all of the characters of the copyright header.